### PR TITLE
export retention details

### DIFF
--- a/nip11.ts
+++ b/nip11.ts
@@ -126,7 +126,7 @@ export interface Limitations {
   restricted_writes: boolean
 }
 
-interface RetentionDetails {
+export interface RetentionDetails {
   kinds: (number | number[])[]
   time?: number | null
   count?: number | null


### PR DESCRIPTION
Was the only interface in nip11 not exported.